### PR TITLE
Add additional ESlint rules for consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@
 | `npm run start` | Starts app in development mode |
 | `npm run build` | Builds the app for production |
 | `npm run test`  | Runs test for the app (in *.test.js files) |
+| `npm run lint`  | Runs ESLint on the project |

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint ."
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,12 @@
       "react-app/jest"
     ],
     "rules": {
+      "linebreak-style": ["warn", "unix"],
+      "indent": ["warn", 2],
+      "no-trailing-spaces": "warn",
+      "eol-last": ["warn", "always"],
+      "import/no-duplicates": "error",
+      "import/no-namespace": "error",
       "import/no-relative-parent-imports": "warn"
     }
   },


### PR DESCRIPTION
- LF (unix) linebreak styles
- Indent of 2 spaces
- No trailing spaces
- Newline at the end of a file
- No duplicate imports
- No entire namespace imports
- No relative parents imports (use 'Components/cmp/Cmp' instead of '../../Components/cmp/Cmp')
