### PR TITLE
Persist spotify auth data in Firebase

### DIFF
--- a/src/Components/SpotifyLoginButton/SpotifyLoginButton.js
+++ b/src/Components/SpotifyLoginButton/SpotifyLoginButton.js
@@ -1,7 +1,7 @@
 import spotifyConfig from "Config/spotify";
+import SpotifyLoginButtonView from "./SpotifyLoginButtonView";
 
-
-const SpotifyAuth = function () {
+const SpotifyLoginButton = function() {
   const urlParams = new URLSearchParams({
     client_id: spotifyConfig.clientId,
     redirect_uri: spotifyConfig.redirectUri,
@@ -10,11 +10,9 @@ const SpotifyAuth = function () {
     show_dialog: "true"
   });
 
-  return (
-    <a href={`${spotifyConfig.authEndpoint}?${urlParams.toString()}`}>
-      Login to Spotify
-    </a>
-  )
-}
+  const url = `${spotifyConfig.authEndpoint}?${urlParams.toString()}`;
 
-export default SpotifyAuth;
+  return <SpotifyLoginButtonView url={url} />;
+};
+
+export default SpotifyLoginButton;

--- a/src/Components/SpotifyLoginButton/SpotifyLoginButtonView.js
+++ b/src/Components/SpotifyLoginButton/SpotifyLoginButtonView.js
@@ -1,0 +1,9 @@
+const SpotifyLoginButtonView = function ({ url }) {
+  return (
+    <a href={url}>
+      Login to Spotify
+    </a>
+  )
+};
+
+export default SpotifyLoginButtonView;

--- a/src/Config/spotify.example.js
+++ b/src/Config/spotify.example.js
@@ -6,7 +6,7 @@
 const spotifyConfig = {
   clientId: "???",
   authEndpoint: 'https://accounts.spotify.com/authorize',
-  redirectUri: "http://localhost:3000/auth",
+  redirectUri: "http://localhost:3000/spotify-callback",
   // https://developer.spotify.com/documentation/general/guides/authorization/scopes/
   scopes: [
     "user-read-currently-playing",

--- a/src/Pages/App/App.js
+++ b/src/Pages/App/App.js
@@ -1,5 +1,6 @@
 import LogoutButton from "Components/LogoutButton/LogoutButton";
 import { Navigate } from "react-router";
+import { Link } from "react-router-dom";
 import useAuthentication from "Services/firebase/useAuthentication";
 
 const App = function () {
@@ -20,6 +21,8 @@ const App = function () {
       <span>Hello there, {user.email}!</span>
 
       <LogoutButton />
+
+      <Link to="/settings">Settings</Link>
     </div>
   );
 };

--- a/src/Pages/LandingPage/LandingPage.js
+++ b/src/Pages/LandingPage/LandingPage.js
@@ -1,5 +1,4 @@
 import { Link } from "react-router-dom";
-import SpotifyAuth from "Components/Spotify/SpotifyAuth";
 
 const LandingPage = function () {
   return (
@@ -8,8 +7,6 @@ const LandingPage = function () {
       <br />
       <br />
       <Link to="/app">Open it</Link>
-      <br />
-      <SpotifyAuth />
     </div>
   );
 };

--- a/src/Pages/SettingsPage/SettingsPage.js
+++ b/src/Pages/SettingsPage/SettingsPage.js
@@ -2,9 +2,15 @@ import LogoutButton from "Components/LogoutButton/LogoutButton";
 import SpotifyLoginButton from "Components/SpotifyLoginButton/SpotifyLoginButton";
 import { Navigate } from "react-router";
 import useAuthentication from "Services/firebase/useAuthentication";
+import useSpotifyAuthData from "Store/selectors/useSpotifyAuthData";
+import useTitle from "Utils/useTitle";
 
 const SettingsPage = function () {
+  useTitle("Bragi 3000 - Settings");
+
   const { authReady, loggedIn, user } = useAuthentication();
+
+  const spotifyAuthData = useSpotifyAuthData();
 
   if (!authReady)
     return (
@@ -18,7 +24,11 @@ const SettingsPage = function () {
 
   return (
     <div>
+      <span>Your token: {user.uid}</span>
+      <br />
       <span>Your email: {user.email}</span>
+      <br />
+      <span>{JSON.stringify(spotifyAuthData)}</span>
       <br />
       <SpotifyLoginButton />
       <br />

--- a/src/Pages/SettingsPage/SettingsPage.js
+++ b/src/Pages/SettingsPage/SettingsPage.js
@@ -1,0 +1,30 @@
+import LogoutButton from "Components/LogoutButton/LogoutButton";
+import SpotifyLoginButton from "Components/SpotifyLoginButton/SpotifyLoginButton";
+import { Navigate } from "react-router";
+import useAuthentication from "Services/firebase/useAuthentication";
+
+const SettingsPage = function () {
+  const { authReady, loggedIn, user } = useAuthentication();
+
+  if (!authReady)
+    return (
+      <span>Waiting for auth...</span>
+    );
+
+  if (!loggedIn)
+    return (
+      <Navigate replace to="/login" />
+    );
+
+  return (
+    <div>
+      <span>Your email: {user.email}</span>
+      <br />
+      <SpotifyLoginButton />
+      <br />
+      <LogoutButton />
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/src/Pages/SpotifyCallbackPage/SpotifyCallbackPage.js
+++ b/src/Pages/SpotifyCallbackPage/SpotifyCallbackPage.js
@@ -1,7 +1,7 @@
 import tokenExtractor from "Utils/Spotify/TokenExtractor";
 // import { getPlaybackState, addSongToQueue, searchSong, pauseSong, playSong } from "Services/Spotify/spotifyAPI";
 
-const SpotifyTokenHandler = function () {
+const SpotifyCallbackPage = function () {
   const token = tokenExtractor();
   console.log(token.access_token);
   // getPlaybackState(token.access_token);
@@ -17,4 +17,4 @@ const SpotifyTokenHandler = function () {
   )
 }
 
-export default SpotifyTokenHandler;
+export default SpotifyCallbackPage;

--- a/src/Pages/SpotifyCallbackPage/SpotifyCallbackPage.js
+++ b/src/Pages/SpotifyCallbackPage/SpotifyCallbackPage.js
@@ -1,20 +1,31 @@
-import tokenExtractor from "Utils/Spotify/TokenExtractor";
-// import { getPlaybackState, addSongToQueue, searchSong, pauseSong, playSong } from "Services/Spotify/spotifyAPI";
+import { useEffect } from "react";
+import { Navigate } from "react-router";
+import useAuthentication from "Services/firebase/useAuthentication";
+import useSetSpotifyAuthData from "Store/updaters/useSetSpotifyAuthData";
+import useHashParams from "Utils/useHashParams";
 
 const SpotifyCallbackPage = function () {
-  const token = tokenExtractor();
-  console.log(token.access_token);
-  // getPlaybackState(token.access_token);
-  // pauseSong(token.access_token);
-  // playSong(token.access_token);
-  // searchSong(token.access_token, "Never")
+  const { authReady, loggedIn } = useAuthentication();
+  const params = useHashParams();
+  const setSpotifyAuthData = useSetSpotifyAuthData();
 
-  return (
-    <div>
-      {token.access_token && (<span>Authenticated</span>)}
-      {!token.access_token && (<span>Authentication failed</span>)}
-    </div>
-  )
+  useEffect(() => {
+    if (authReady && loggedIn && params.get("access_token")) {
+      setSpotifyAuthData({
+        access_token: params.get("access_token"),
+        token_type: params.get("token_type"),
+        expires: Date.now() + (parseInt(params.get("expires_in") * 1000))
+      });
+    }
+  }, [authReady, loggedIn, params, setSpotifyAuthData]);
+
+  if (!authReady)
+    return <span>Waiting for auth...</span>;
+
+  if (!loggedIn)
+    return <Navigate replace to="/login" />;
+
+  return <Navigate replace to="/settings" />;
 }
 
 export default SpotifyCallbackPage;

--- a/src/Store/hooks/useSpotifyAuthData.js
+++ b/src/Store/hooks/useSpotifyAuthData.js
@@ -1,0 +1,22 @@
+import { useSelector } from "react-redux";
+import { useFirebase, useFirebaseConnect } from "react-redux-firebase";
+import useAuthentication from "Services/firebase/useAuthentication";
+
+const useSpotifyAuthData = function () {
+  const firebase = useFirebase();
+  const { user } = useAuthentication();
+  const path = `users/${user.uid}/spotifyAuthData`;
+
+  useFirebaseConnect(path);
+  const data = useSelector(({ firebase: { data }}) => (
+    (data.users && data.users[user.uid] && data.users[user.uid].spotifyAuthData)
+  ));
+
+  const setter = (newData) => (
+    firebase.set(path, newData)
+  );
+
+  return [data, setter];
+}
+
+export default useSpotifyAuthData;

--- a/src/Store/selectors/useSpotifyAuthData.js
+++ b/src/Store/selectors/useSpotifyAuthData.js
@@ -1,22 +1,15 @@
 import { useSelector } from "react-redux";
-import { useFirebase, useFirebaseConnect } from "react-redux-firebase";
+import { useFirebaseConnect } from "react-redux-firebase";
 import useAuthentication from "Services/firebase/useAuthentication";
 
 const useSpotifyAuthData = function () {
-  const firebase = useFirebase();
   const { user } = useAuthentication();
   const path = `users/${user.uid}/spotifyAuthData`;
 
   useFirebaseConnect(path);
-  const data = useSelector(({ firebase: { data }}) => (
+  return useSelector(({ firebase: { data } }) => (
     (data.users && data.users[user.uid] && data.users[user.uid].spotifyAuthData)
   ));
-
-  const setter = (newData) => (
-    firebase.set(path, newData)
-  );
-
-  return [data, setter];
 }
 
 export default useSpotifyAuthData;

--- a/src/Store/updaters/useSetSpotifyAuthData.js
+++ b/src/Store/updaters/useSetSpotifyAuthData.js
@@ -1,0 +1,16 @@
+import { useCallback } from "react";
+import { useFirebase } from "react-redux-firebase";
+import useAuthentication from "Services/firebase/useAuthentication";
+
+const useSetSpotifyAuthData = function () {
+  const { user } = useAuthentication();
+  const path = `users/${user.uid}/spotifyAuthData`;
+
+  const firebase = useFirebase();
+  return useCallback((data) => {
+    if (user.uid)
+      firebase.set(path, data);
+  }, [user.uid, firebase, path]);
+}
+
+export default useSetSpotifyAuthData;

--- a/src/Utils/Spotify/TokenExtractor.js
+++ b/src/Utils/Spotify/TokenExtractor.js
@@ -1,8 +1,0 @@
-const tokenExtractor = function () {
-  const paramString = window.location.hash.substring(1);
-  const params = new URLSearchParams(paramString);
-
-  return Object.fromEntries(params);
-}
-
-export default tokenExtractor;

--- a/src/Utils/useHashParams.js
+++ b/src/Utils/useHashParams.js
@@ -1,0 +1,13 @@
+import { useMemo } from "react";
+import { useLocation } from "react-router";
+
+const useHashParams = function () {
+  const location = useLocation();
+
+  return useMemo(() => {
+    const paramString = location.hash.substring(1);
+    return new URLSearchParams(paramString);
+  }, [location.hash]);
+};
+
+export default useHashParams;

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import { ReactReduxFirebaseProvider } from "react-redux-firebase";
 
 import firebaseConfig from "Config/firebase";
 import store from "Store/store";
-import SpotifyTokenHandler from "Pages/SpotifyTokenHandler/SpotifyTokenHandler";
+import SpotifyCallbackPage from "Pages/SpotifyCallbackPage/SpotifyCallbackPage";
 import LandingPage from "Pages/LandingPage/LandingPage";
 import App from "Pages/App/App";
 import LoginPage from "Pages/LoginPage/LoginPage";
@@ -32,7 +32,7 @@ ReactDOM.render(
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/signup" element={<SignupPage />} />
-            <Route path="/auth" element={<SpotifyTokenHandler />} />
+            <Route path="/spotify-callback" element={<SpotifyCallbackPage />} />
           </Routes>
         </BrowserRouter>
       </ReactReduxFirebaseProvider>

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ ReactDOM.render(
     <Provider store={store}>
       <ReactReduxFirebaseProvider
         firebase={firebase}
-        config={{ userProfile: "users" }}
+        config={{}}
         dispatch={store.dispatch}>
         <BrowserRouter>
           <Routes>

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import LandingPage from "Pages/LandingPage/LandingPage";
 import App from "Pages/App/App";
 import LoginPage from "Pages/LoginPage/LoginPage";
 import SignupPage from "Pages/SignupPage/SignupPage";
+import SettingsPage from "Pages/SettingsPage/SettingsPage";
 
 firebase.initializeApp(firebaseConfig);
 
@@ -28,6 +29,7 @@ ReactDOM.render(
           <Routes>
             <Route path="/" element={<LandingPage />} />
             <Route path="/app" element={<App />} />
+            <Route path="/settings" element={<SettingsPage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/signup" element={<SignupPage />} />
             <Route path="/auth" element={<SpotifyTokenHandler />} />


### PR DESCRIPTION
Resolves #19 

- Selectors and updaters for the auth data to `/users/:user-uid/spotifyAuthData` in Firebase (access-restricted)
- Adds settings page that shows the persisted token
- Takes data from callback (**OBS**: now moved to `/spotify-callback`), and saves it.

**OBS**: Using this requires a new spotify config file, with the redirect url set to `http://localhost:3000/spotify-callback` (and this url should also be added in the Dev Dashboard)