### PR TITLE
Fix: temporary button to get out of settings to the app #38

### DIFF
--- a/src/Pages/SettingsPage/SettingsPage.js
+++ b/src/Pages/SettingsPage/SettingsPage.js
@@ -3,6 +3,7 @@ import SpotifyLoginButton from "Components/SpotifyLoginButton/SpotifyLoginButton
 import useUserData from "Services/firebase/useUserData";
 import useSpotifyAuthData from "Store/selectors/useSpotifyAuthData";
 import useTitle from "Utils/useTitle";
+import { Link } from "react-router-dom";
 
 const SettingsPage = function () {
   useTitle("Bragi 3000 - Settings");
@@ -22,6 +23,9 @@ const SettingsPage = function () {
       <SpotifyLoginButton />
       <br />
       <LogoutButton />
+      <br />
+      <br />
+      <Link to="/app">Start playing</Link>
     </div>
   );
 };


### PR DESCRIPTION
Resolves #38 
Just a temporary way for the mid-project review to get from settings to the app