### PR TITLE
Fix: redirect on token failure to settings #58

### DIFF
--- a/src/Pages/SpotifyCallbackPage/SpotifyCallbackPage.js
+++ b/src/Pages/SpotifyCallbackPage/SpotifyCallbackPage.js
@@ -21,6 +21,8 @@ const SpotifyCallbackPage = function () {
       }).then(() => {
         navigate("/settings");
       });
+    } else {
+      navigate("/settings");
     }
   }, [params, setSpotifyAuthData, navigate]);
 


### PR DESCRIPTION
Closes #58 
Simply redirect user to settings again on failure, updated settings site shows that user needs to be logged in to spotify 