### PR TITLE
Device transfer requires active playback

### DIFF
--- a/src/Components/SpotifyControl/DeviceSelector/DeviceSelector.js
+++ b/src/Components/SpotifyControl/DeviceSelector/DeviceSelector.js
@@ -4,10 +4,11 @@ import {
   fetchDevices,
   selectDevices,
   setActiveDevice,
-  selectActiveDevice,
+  selectActiveDevice, setActiveDeviceState,
 } from "Store/slices/devices";
 import { selectSpotifyAccessToken } from "Store/slices/spotifyAuth";
 import DeviceSelectorView from "./DeviceSelectorView";
+import {selectPlaylistId} from "Store/slices/playlist";
 
 /**
  * A list of Spotify devices from which the active device can be chosen.
@@ -29,10 +30,11 @@ const DeviceSelector = function () {
 
   const devices = useSelector((state) => selectDevices(state));
   const activeDeviceId = useSelector((state) => selectActiveDevice(state));
+  const playlistId = useSelector((state) => selectPlaylistId(state));
 
   const handleSelectDeviceId = async (deviceId) => {
-    await dispatch(setActiveDevice({ accessToken, deviceId })).unwrap();
-    await dispatch(fetchDevices({ accessToken })).unwrap();
+    await dispatch(setActiveDevice({ accessToken, deviceId, playlistId })).unwrap();
+    await dispatch(setActiveDeviceState(deviceId));
   };
 
   return (

--- a/src/Components/SpotifyControl/SpotifyControl.js
+++ b/src/Components/SpotifyControl/SpotifyControl.js
@@ -9,7 +9,7 @@ import {
   togglePlayPause
 } from "Store/slices/playback";
 import {
-  selectActiveDevice
+  selectActiveDevice, setActiveDeviceState
 } from "Store/slices/devices";
 import {selectPlaylistId} from "../../Store/slices/playlist";
 import { selectSpotifyAccessToken } from "Store/slices/spotifyAuth";
@@ -45,7 +45,7 @@ const SpotifyControl = function () {
    * Callback function when the play/pause button is clicked
    */
   const handlePlay = async () => {
-    if (!playbackState.started_playlist && playlistSongs.length === 0) {
+    if (!playbackState.is_playing && !playbackState.started_playlist && playlistSongs.length === 0) {
       infoToast("Your playlist is still empty");
       return;
     }
@@ -55,7 +55,8 @@ const SpotifyControl = function () {
     }
     if (!playbackState.started_playlist && !playbackState.is_playing) {
       // start playing bragi3000 playlist
-      await startPlaylist(accessToken, playlistId);
+      await startPlaylist(accessToken, playlistId, activeDevice);
+      await dispatch(setActiveDeviceState(activeDevice));
       dispatch(setStartedPlaylist(true));
     } else {
       const togglePlayPauseFunc = playbackState.is_playing ? pauseSong : playSong;

--- a/src/Components/SpotifyControl/SpotifyControl.js
+++ b/src/Components/SpotifyControl/SpotifyControl.js
@@ -49,15 +49,14 @@ const SpotifyControl = function () {
       infoToast("Your playlist is still empty");
       return;
     }
+    if (!activeDevice) {
+      infoToast("Please select a a device first");
+      return;
+    }
     if (!playbackState.started_playlist && !playbackState.is_playing) {
-      if (activeDevice) {
-        // start playing bragi3000 playlist
-        await startPlaylist(accessToken, playlistId);
-        dispatch(setStartedPlaylist(true));
-      } else {
-        infoToast("Please select a a device first");
-        return;
-      }
+      // start playing bragi3000 playlist
+      await startPlaylist(accessToken, playlistId);
+      dispatch(setStartedPlaylist(true));
     } else {
       const togglePlayPauseFunc = playbackState.is_playing ? pauseSong : playSong;
       await togglePlayPauseFunc(accessToken);

--- a/src/Services/Spotify/spotifyAPI.js
+++ b/src/Services/Spotify/spotifyAPI.js
@@ -1,6 +1,6 @@
 import SpotifyWebApi from "spotify-web-api-node";
 import bragi_icon_b64 from "Assets/images/bragi-icon-b64";
-import {errorToast} from "Components/Toast/Toast";
+import {errorToast, infoToast} from "Components/Toast/Toast";
 
 /**
  * Method which calls the spotify API to get information about the playback state of the authenticated user
@@ -230,8 +230,14 @@ function startPlaylist(accessToken, playlistId) {
  * @returns {Promise} - A promise that resolves when the device has been set
  */
 function setActiveDevice(accessToken, deviceId) {
-  return new SpotifyWebApi({accessToken}).transferMyPlayback([deviceId])
-    .catch(() => errorToast("Error while setting active device"));
+  new SpotifyWebApi({accessToken}).getMyCurrentPlaybackState().then(data => {
+    if (!(data.body && data.body.is_playing)) {
+      infoToast("No active playback, please start a random song on one device");
+    } else {
+      return new SpotifyWebApi({accessToken}).transferMyPlayback([deviceId])
+        .catch(() => errorToast("Error while setting active device"));
+    }
+  })
 }
 
 /**

--- a/src/Store/slices/devices.js
+++ b/src/Store/slices/devices.js
@@ -21,7 +21,10 @@ export const fetchDevices = createAsyncThunk(
  */
 export const setActiveDevice = createAsyncThunk(
   "devices/setActiveDevice",
-  ({ accessToken, deviceId }) => apiSetActiveDevice(accessToken, deviceId)
+  ({ accessToken, deviceId}, {getState}) => {
+    const playlistId = getState().playlist.playlistId;
+    return apiSetActiveDevice(accessToken, deviceId, playlistId);
+  }
 );
 
 /**
@@ -49,7 +52,16 @@ const initialState = {
 const devices = createSlice({
   name: "devices",
   initialState,
-  reducers: {},
+  reducers: {
+    /**
+     *  Action & reducer to set the active device
+     * @param state - The current state of the store
+     * @param payload - The active device to bet set
+     */
+    setActiveDeviceState: (state, {payload}) => {
+      state.active.data = payload
+    }
+  },
   extraReducers: {
     /**
      * Reducer for a pending fetchDevices request
@@ -111,6 +123,7 @@ const devices = createSlice({
 });
 
 export default devices.reducer;
+export const {setActiveDeviceState} = devices.actions;
 
 /**
  * Selector for devices in the playback state

--- a/src/Store/slices/spotifyAuth.js
+++ b/src/Store/slices/spotifyAuth.js
@@ -62,6 +62,7 @@ const setExpired = spotifyAuthSlice.actions.setExpired;
  */
 export default spotifyAuthSlice.reducer;
 
+let triggerFetchPlaylistId = false;
 /**
  * Action to set the Spotify authentication data
  * @param accessToken Spotify access token
@@ -86,12 +87,14 @@ export const setSpotifyAuthData =
             : null,
       })
     );
-
-    dispatch(fetchPlaylistId({ accessToken })).unwrap().then(
-      (playlistId)=> {
-        dispatch(setPlaylistId(playlistId));
-        dispatch(fetchPlaylistSongs({ accessToken }))
-      });
+    if (!triggerFetchPlaylistId) {
+      triggerFetchPlaylistId = true;
+      dispatch(fetchPlaylistId({ accessToken })).unwrap().then(
+        (playlistId)=> {
+          dispatch(setPlaylistId(playlistId));
+          dispatch(fetchPlaylistSongs({ accessToken }))
+        });
+    }
 };
 
 /**


### PR DESCRIPTION
- Request user to start a song on device, in order to get active playback state which we can transfer
- Check if there is actually an active device before toggling play/pause

Not perfect, open for any suggestions